### PR TITLE
Silence 64 bit warning

### DIFF
--- a/Component/private/CPAnimationStep.m
+++ b/Component/private/CPAnimationStep.m
@@ -112,7 +112,7 @@
 		[result appendFormat:@"for:%.1f ", self.duration];
 	}
 	if (self.options > 0) {
-		[result appendFormat:@"options:%d ", self.options];
+		[result appendFormat:@"options:%lu ", (unsigned long)self.options];
 	}
 	[result appendFormat:@"animate:%@", self.step];
 	[result appendString:@"]"];


### PR DESCRIPTION
When building for 64 bit devices, the following warning is triggered in `[CPAnimationStep description]`:

```
CPAnimationSequence/Component/private/CPAnimationStep.m:115:40: Format specifies type 'int' but the argument has type 'UIViewAnimationOptions' (aka 'enum UIViewAnimationOptions')
```

This casts the `NSUInteger` causing that issue to an `unsigned long`, silencing the warning.
