### PR TITLE
Add spring animation functionality

### DIFF
--- a/AnimationSequence/AnimationSequenceViewController.m
+++ b/AnimationSequence/AnimationSequenceViewController.m
@@ -70,9 +70,10 @@
 			[CPAnimationStep after:0.7 for:1.0 animate:^{ [self highlightLabel:self.labelStep1];
 														  self.theBox.frame = CGRectMake(150, 150, 100, 100); }],
 			[CPAnimationStep after:0.7 for:1.0 animate:^{ [self highlightLabel:self.labelStep2];
-														  self.theBox.backgroundColor = [UIColor orangeColor]; }],
-			[CPAnimationStep after:0.7 for:1.0 animate:^{ [self highlightLabel:self.labelStep3];
-														  self.theBox.transform = CGAffineTransformMakeScale(2.0, 2.0); }],
+		self.theBox.backgroundColor = [UIColor orangeColor]; }],
+			[CPAnimationStep after:0.7 for:1.0 damping:0.5 velocity:1 options:0 animate:^{
+		[self highlightLabel:self.labelStep3];
+		self.theBox.transform = CGAffineTransformMakeScale(2.0, 2.0); }],
 			[CPAnimationStep after:0.0         animate:^{ [self highlightLabel:nil]; }],
 			nil];
 }

--- a/Component/CPAnimationStep.h
+++ b/Component/CPAnimationStep.h
@@ -32,10 +32,19 @@ typedef CPAnimationStepBlock AnimationStep __deprecated;
 	 options:(UIViewAnimationOptions)theOptions
 	 animate:(CPAnimationStepBlock)step;
 
++ (id) after:(NSTimeInterval)delay
+		 for:(NSTimeInterval)duration
+	 damping:(CGFloat) dampingRatio
+	velocity:(CGFloat) velocity
+	 options:(UIViewAnimationOptions)theOptions
+	 animate:(CPAnimationStepBlock)step;
+
 #pragma mark - properties (normally already set by the constructor)
 
 @property (nonatomic) NSTimeInterval delay;
 @property (nonatomic) NSTimeInterval duration;
+@property (nonatomic) CGFloat damping;
+@property (nonatomic) CGFloat velocity;
 @property (nonatomic, copy) CPAnimationStepBlock step;
 @property (nonatomic) UIViewAnimationOptions options;
 

--- a/Component/private/CPAnimationStep.m
+++ b/Component/private/CPAnimationStep.m
@@ -17,27 +17,39 @@
 #pragma mark construction
 
 + (id) after:(NSTimeInterval)delay animate:(CPAnimationStepBlock)step {
-	return [self after:delay for:0.0 options:0 animate:step];
+	return [self after:delay for:0.0 damping:1 velocity:0 options:0 animate:step];
 }
 
 + (id) for:(NSTimeInterval)duration animate:(CPAnimationStepBlock)step {
-   return [self after:0.0 for:duration options:0 animate:step];
+	return [self after:0.0 for:duration damping:1 velocity:0 options:0 animate:step];
 }
 
 + (id) after:(NSTimeInterval)delay for:(NSTimeInterval)duration animate:(CPAnimationStepBlock)step {
-	return [self after:delay for:duration options:0 animate:step];
+	return [self after:delay for:duration damping:1 velocity:0 options:0 animate:step];
+}
+
++ (id)after:(NSTimeInterval)delay
+		for:(NSTimeInterval)duration
+	options:(UIViewAnimationOptions)theOptions
+	animate:(CPAnimationStepBlock)step
+{
+	return [self after:delay for:duration damping:1 velocity:0 options:theOptions animate:step];
 }
 
 + (id) after:(NSTimeInterval)theDelay
 		 for:(NSTimeInterval)theDuration
+	 damping:(CGFloat) dampingRatio
+	velocity:(CGFloat) velocity
 	 options:(UIViewAnimationOptions)theOptions
-	 animate:(CPAnimationStepBlock)theStep {
-	
+	 animate:(CPAnimationStepBlock)theStep
+{
 	CPAnimationStep* instance = [[self alloc] init];
 	if (instance) {
 		instance.delay = theDelay;
 		instance.duration = theDuration;
 		instance.options = theOptions;
+		instance.damping = dampingRatio;
+		instance.velocity = velocity;
 		instance.step = [theStep copy];
 	}
 	return instance;
@@ -81,6 +93,8 @@
 	if (animated && currentStep.duration >= 0.02) {
 		[UIView animateWithDuration:currentStep.duration
 							  delay:currentStep.delay
+			 usingSpringWithDamping:currentStep.damping
+			  initialSpringVelocity:currentStep.velocity
 							options:currentStep.options
 						 animations:[currentStep animationStep:animated]
 						 completion:^(BOOL finished) {
@@ -120,6 +134,12 @@
 	}
 	if (self.duration > 0.0) {
 		[result appendFormat:@"for:%.1f ", self.duration];
+	}
+	if (self.damping < 1.0) {
+		[result appendFormat:@"damping:%.1f ", self.damping];
+	}
+	if (self.damping < 1.0) {
+		[result appendFormat:@"velocity:%.1f ", self.velocity];
 	}
 	if (self.options > 0) {
 		[result appendFormat:@"options:%lu ", (unsigned long)self.options];


### PR DESCRIPTION
Resolves #13 

From the documentation it seems that the spring animation method can be used for all other animation types provided that the spring damping is set to `1.0` when no effective bouncing is desired. I've taken this approach so as not to change much of the existing functionality in order to support this and it appears to work nicely with very minimal changes.

Note, not very thoroughly tested right now!
